### PR TITLE
Add TREK app deployment

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cert-manager
+  - ./database
+  - ./default
+  - ./disk
+  - ./flux-system
+  - ./immich
+  - ./kube-system
+  - ./network
+  - ./trek

--- a/kubernetes/apps/trek/kustomization.yaml
+++ b/kubernetes/apps/trek/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: trek
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./trek/ks.yaml

--- a/kubernetes/apps/trek/namespace.yaml
+++ b/kubernetes/apps/trek/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trek
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/trek/trek/app/helmrelease.yaml
+++ b/kubernetes/apps/trek/trek/app/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trek
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: trek
+      interval: 12h
+      version: 2.9.13
+      sourceRef:
+        kind: HelmRepository
+        name: trek
+  values:
+    env:
+      ALLOWED_ORIGINS: "https://trek.${SECRET_DOMAIN}"
+      APP_URL: "https://trek.${SECRET_DOMAIN}"
+      FORCE_HTTPS: "true"
+      TRUST_PROXY: "1"
+      TZ: Europe/Berlin
+    existingSecret: trek-secret
+    existingSecretKey: ENCRYPTION_KEY
+    persistence:
+      enabled: true
+      data:
+        size: 10Gi
+      uploads:
+        size: 10Gi
+  # The upstream chart does not expose storageClassName, so patch the rendered PVCs.
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: all
+              spec:
+                storageClassName: tns-csi-iscsi
+            target:
+              kind: PersistentVolumeClaim
+              name: trek-(data|uploads)

--- a/kubernetes/apps/trek/trek/app/helmrepository.yaml
+++ b/kubernetes/apps/trek/trek/app/helmrepository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: trek
+spec:
+  interval: 12h
+  url: https://mauriceboe.github.io/TREK

--- a/kubernetes/apps/trek/trek/app/httproute.yaml
+++ b/kubernetes/apps/trek/trek/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: trek
+spec:
+  hostnames: ["trek.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: trek
+          namespace: trek
+          port: 3000

--- a/kubernetes/apps/trek/trek/app/kustomization.yaml
+++ b/kubernetes/apps/trek/trek/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/trek/trek/app/secret.sops.yaml
+++ b/kubernetes/apps/trek/trek/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trek-secret
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: ENC[AES256_GCM,data:f4KP6emVq7XUGHbqItKDbmSB86rLGeLsJpC/hWQx627GlT2q/8FyldAcUe6Mb92DCFqX0hgEo48Zec8mfTTuQA==,iv:pVeuNAiJ+CExtsv3I63zcc/h0wibNUevjB6XE8NSPgk=,tag:d2YROu0fNM6/04kTtuc84Q==,type:str]
+sops:
+  age:
+    - recipient: age1vyl3eet632wd4xh7zfgp44z4qkafpj0tlpn246jpqezrh5zg496s68jrjj
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5M29UN0pZK1l0VWwzZFBT
+        L0l6WGlHYXdtdDVFWGNKMnJRa1dsTXZjaUdJCk1aQnBBcTNyMlhnT3cvWHpvVnIy
+        aHFMVTJ3MERvYWtDdHJXb21GelJ3ZU0KLS0tIDZocDNLOFUwTkZXcWl0MjgvTExv
+        ZE16YUkzWjdnR253MXlvbGpkL2FiQTgKmTxVmih16KvsTNPLuPlQAr7/FegMMQgV
+        lU7qC3abl7CmvXPLx7WcE7E/t8uBl5It6LDbCKWxAstle55K/fMEeQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-12T18:12:20Z"
+  mac: ENC[AES256_GCM,data:DLxuc8nIIEQs8+h/okLYYKKZuSLU3J1mH2OoNKG/AWAF/Qkcc8jIlJCu8C809dMc1J1MEZC05JZORYR4xHVDCsQ1Tn7y/X+SBrTHQJZ8ppyysr9d44OaIrxC6Ug9qXPV8OSaiuvwQ1dNdZOqjbe2WCHU7OnYp6JjaQXk54Cv1nQ=,iv:cCUy8zC76S7aql2DiT6qBxW/ClnRgK0psrOBmMUdc8E=,tag:ljmmVujHyxYrP+4Cpz5I5Q==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.2

--- a/kubernetes/apps/trek/trek/ks.yaml
+++ b/kubernetes/apps/trek/trek/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: trek
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/trek/trek/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: trek
+  wait: false


### PR DESCRIPTION
## Summary
Add TREK as a Flux-managed app exposed at `https://trek.${SECRET_DOMAIN}`.

## Changes
- add the new `trek` app group and namespace
- add `HelmRepository` and `HelmRelease` for the upstream TREK chart
- add external `HTTPRoute` through `envoy-external`
- configure persistence and `ENCRYPTION_KEY`
- patch the chart PVCs to use `tns-csi-iscsi`

## Validation
- `kustomize build kubernetes/apps/trek`
- `kustomize build kubernetes/apps`
- `helm template` against the upstream TREK chart